### PR TITLE
Extracting SPI from direct implementation

### DIFF
--- a/examples/Viper-FPGA-Control-RgbLed/Viper-FPGA-Control-RgbLed.ino
+++ b/examples/Viper-FPGA-Control-RgbLed/Viper-FPGA-Control-RgbLed.ino
@@ -8,11 +8,29 @@
 
 #include <ArduinoViperFpga.h>
 
+#include <SPI.h>
+
+/**************************************************************************************
+ * GLOBAL CONSTANTS
+ **************************************************************************************/
+
+static int const FPGA_CS_PIN = 3; /* Pin 3 = D3 = PA11 */
+
+/**************************************************************************************
+ * FUNCTION DECLARATION
+ **************************************************************************************/
+
+void    spi_select  ();
+void    spi_deselect();
+uint8_t spi_transfer(uint8_t const);
+
 /**************************************************************************************
  * GLOBAL VARIABLES
  **************************************************************************************/
 
-ArduinoViperFpga fpga;
+ArduinoViperFpga fpga(spi_select,
+                      spi_deselect,
+                      spi_transfer);
 
 /**************************************************************************************
  * SETUP/LOOP
@@ -22,6 +40,11 @@ void setup()
 {
   Serial.begin(115200);
   while(!Serial) { }
+
+  /* Setup SPI access */
+  SPI.begin();
+  pinMode(FPGA_CS_PIN, OUTPUT);
+  digitalWrite(FPGA_CS_PIN, HIGH);
 
   if(ArduinoViperFpga::Status::OK != fpga.begin()) {
     Serial.println("ArduinoViperFpga::begin() failed");
@@ -38,4 +61,23 @@ void setup()
 void loop()
 {
 
+}
+
+/**************************************************************************************
+ * FUNCTION DEFINITION
+ **************************************************************************************/
+
+void spi_select()
+{
+  digitalWrite(FPGA_CS_PIN, LOW);
+}
+
+void spi_deselect()
+{
+  digitalWrite(FPGA_CS_PIN, HIGH);
+}
+
+uint8_t spi_transfer(uint8_t const data)
+{
+  return SPI.transfer(data);
 }

--- a/src/ArduinoViperFpga.cpp
+++ b/src/ArduinoViperFpga.cpp
@@ -20,8 +20,8 @@ extern void enableFpgaClock(); /* Defined within MKRVIDOR4000/variant.cpp */
  * CTOR/DTOR
  **************************************************************************************/
 
-ArduinoViperFpga::ArduinoViperFpga()
-: _io_reg(SPI)
+ArduinoViperFpga::ArduinoViperFpga(ViperFpga::SpiSelectFunc select, ViperFpga::SpiDeselectFunc deselect, ViperFpga::SpiTransferFunc transfer)
+: _io_reg(select, deselect, transfer)
 {
 
 }

--- a/src/ArduinoViperFpga.h
+++ b/src/ArduinoViperFpga.h
@@ -22,7 +22,7 @@ class ArduinoViperFpga
 
 public:
 
-  ArduinoViperFpga();
+  ArduinoViperFpga(ViperFpga::SpiSelectFunc select, ViperFpga::SpiDeselectFunc deselect, ViperFpga::SpiTransferFunc transfer);
 
 
   enum class Status : int

--- a/src/ViperFpga/RegisterIo.h
+++ b/src/ViperFpga/RegisterIo.h
@@ -13,7 +13,9 @@
 
 #include <stdint.h>
 
-#include <SPI.h>
+#undef max
+#undef min
+#include <functional>
 
 /**************************************************************************************
  * NAMESPACE
@@ -23,14 +25,12 @@ namespace ViperFpga
 {
 
 /**************************************************************************************
- * CONSTANTS
- **************************************************************************************/
-
-static int const FPGA_CS_PIN = 3; /* Pin 3 = D3 = PA11 */
-
-/**************************************************************************************
  * TYPEDEF
  **************************************************************************************/
+
+typedef std::function<void()>                 SpiSelectFunc;
+typedef std::function<void()>                 SpiDeselectFunc;
+typedef std::function<uint8_t(uint8_t const)> SpiTransferFunc;
 
 enum class Register : uint8_t
 {
@@ -49,9 +49,8 @@ class RegisterIo
 
 public:
 
-  RegisterIo(SPIClass & spi, int const fpga_cs_pin = FPGA_CS_PIN);
+  RegisterIo(SpiSelectFunc select, SpiDeselectFunc deselect, SpiTransferFunc transfer);
 
-  void    begin();
 
   uint8_t read (Register const reg);
   void    write(Register const reg, uint8_t const reg_val);
@@ -59,11 +58,9 @@ public:
 
 private:
 
-  SPIClass & _spi;
-  int const _fpga_cs_pin;
-
-  void select  ();
-  void deselect();
+  SpiSelectFunc _select;
+  SpiDeselectFunc _deselect;
+  SpiTransferFunc _transfer;
 
 };
 


### PR DESCRIPTION
The SPI is going to be shared between multiple IO devices (`MCP2515`, `BMP388`, `FPGA` ...). It can therefore not be implemented directly in the system but must exist outside of it.